### PR TITLE
Rework footer layout

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -16,11 +16,13 @@ module.exports = function () {
     ],
     footerLinks: [
       { href: "/about/", text: "About beeps" },
-      { href: "/brand/", text: "Brand" },
-      { href: "/colophon/", text: "Colophon" },
+      { href: "/brand/", text: "beeps' brand" },
+      { href: "/contact/", text: "Contact beeps" },
+    ],
+    legalLinks: [
       { href: "/links/", text: "Cool links" },
-      { href: "/privacy/", text: "Privacy" },
-      { href: "/contact/", text: "Contact" },
+      { href: "/colophon/", text: "Colophon" },
+      { href: "/privacy/", text: "Cookies and privacy" },
     ],
   };
 };

--- a/src/_includes/color-scheme-switch.njk
+++ b/src/_includes/color-scheme-switch.njk
@@ -3,15 +3,15 @@
 	<div class="kimColorSchemeSwitch_inner">
 		<div class="kimColorSchemeSwitch_item">
 			<input class="kimColorSchemeSwitch_input" type="radio" name="color-scheme" value="auto" id="color-scheme-auto">
-			<label class="kimColorSchemeSwitch_label" for="color-scheme-auto">Auto</label>
+			<label class="kimColorSchemeSwitch_label" for="color-scheme-auto" title="Match system theme">System</label>
 		</div>
 		<div class="kimColorSchemeSwitch_item">
 			<input class="kimColorSchemeSwitch_input" type="radio" name="color-scheme" value="dark" id="color-scheme-dark">
-			<label class="kimColorSchemeSwitch_label" for="color-scheme-dark">Dark</label>
+			<label class="kimColorSchemeSwitch_label" for="color-scheme-dark" title="Light text on a dark background">Dark</label>
 		</div>
 		<div class="kimColorSchemeSwitch_item">
 			<input class="kimColorSchemeSwitch_input" type="radio" name="color-scheme" value="light" id="color-scheme-light">
-			<label class="kimColorSchemeSwitch_label" for="color-scheme-light">Light</label>
+			<label class="kimColorSchemeSwitch_label" for="color-scheme-light" title="Dark text on a light background">Light</label>
 		</div>
 	</div>
 </fieldset>

--- a/src/_layouts/layout.njk
+++ b/src/_layouts/layout.njk
@@ -83,13 +83,31 @@
         </div>
       {% endblock %}
       <div class="kimWrapper kimFooter_inner">
-        <ul class="kimFooter_links" aria-label="Minor content">
-          {%- for link in site.footerLinks %}
-            <li><a class="kimLink" href="{{ link.href | url }}">{{ link.text }}</a></li>
-          {%- endfor%}
-        </ul>
-        <div class="kimFooter_themeSwitch">
-          {% include "src/_includes/color-scheme-switch.njk" %}
+        <div class="kimGrid">
+          <div class="kimGrid_column kimGrid_column-oneHalf defiant:kimGrid_column-oneQuarter">
+            <h2 class="kimHeading-s" id="footer-links-beeps">More beeping</h2>
+            <ul class="kimList kimFooter_links" aria-labelledby="footer-links-beeps">
+              {%- for link in site.footerLinks %}
+                <li><a class="kimLink" href="{{ link.href | url }}">{{ link.text }}</a></li>
+              {%- endfor%}
+            </ul>
+          </div>
+          <div class="kimGrid_column kimGrid_column-oneHalf defiant:kimGrid_column-oneQuarter">
+            <h2 class="kimHeading-s" id="footer-links-other">Things and stuff</h2>
+            <ul class="kimList kimFooter_links" aria-labelledby="footer-links-other">
+              {%- for link in site.legalLinks %}
+                <li><a class="kimLink" href="{{ link.href | url }}">{{ link.text }}</a></li>
+              {%- endfor%}
+            </ul>
+          </div>
+          <div class="kimGrid_column kimGrid_column-full defiant:kimGrid_column-oneHalf">
+            <h2 class="kimHeading-s">Small print</h2>
+            {% block copyrights %}
+            <p class="kimBody-s">Content licensed under <a class="kimLink" href="http://creativecommons.org/licenses/by-nc/4.0/" title="Creative Commons Attribution Non-Commercial 4.0">CC BY-NC 4.0</a>. Code available under the <a class="kimLink" href="https://github.com/querkmachine/beeps.website/blob/main/LICENCE">MIT license</a>. Keep circulating <a class="kimLink" href="https://github.com/querkmachine/beeps.website">the HTML</a>.</p>
+            {% endblock %}
+            
+            {% include "src/_includes/color-scheme-switch.njk" %}
+          </div>
         </div>
       </div>
     </footer>

--- a/src/assets/components/_color-scheme-switch.scss
+++ b/src/assets/components/_color-scheme-switch.scss
@@ -13,7 +13,7 @@
     display: none;
   }
   &_inner {
-    @include typography.kim-font-size(12);
+    @include typography.kim-font-size(16);
     display: inline-flex;
   }
   &_item {
@@ -41,7 +41,7 @@
     }
   }
   &_label {
-    @include spacing.kim-responsive-padding(2, $direction: inline);
+    @include spacing.kim-responsive-padding(3, $direction: inline);
     @include spacing.kim-responsive-padding(1, $direction: block);
     display: inline-block;
     border-width: measurements.kim-border-width("hairline")

--- a/src/assets/components/_footer.scss
+++ b/src/assets/components/_footer.scss
@@ -14,28 +14,8 @@
     display: none;
   }
   &_inner {
-    @include spacing.kim-responsive-padding(3, $direction: block);
-    display: flex;
-    flex-direction: column;
-    gap: settings.$kim-page-gutter * 0.5;
+    @include spacing.kim-responsive-padding(6, $direction: block);
     border-bottom: measurements.kim-border-width("thick") solid
       colors.kim-color-css("furniture");
-    position: relative;
-    @include media-queries.kim-mq($from: defiant) {
-      flex-direction: row;
-      justify-content: flex-end;
-      align-items: center;
-    }
-  }
-  &_links {
-    @include typography.kim-font-size(12);
-    display: block;
-    margin: 0;
-    padding: 0;
-    margin-right: auto;
-    li {
-      @include spacing.kim-responsive-margin(2, $direction: right);
-      display: inline-block;
-    }
   }
 }


### PR DESCRIPTION
Resolves #40. Adds licensing info determined in #38.

## Changes
- Footer links are now presented in categorised columns.
- Footer content is now the same size as body text, by default.
- Footer now includes content and code licensing information.
- Theme switcher tweaks:
  - 'Auto' option renamed to 'System' to try and better describe what it does.
  - Each option includes a `title` describing what it does in more detail.
