### PR TITLE
:bug: Remove metadata removing some pages from collections

### DIFF
--- a/src/colophon.md
+++ b/src/colophon.md
@@ -3,7 +3,6 @@ layout: generic.njk
 title: Colophon
 metadata:
   description: Giving credit to the people and tools that made this website possible.
-eleventyExcludeFromCollections: true
 ---
 
 A colophon is a short section you can find at the back of some books, giving some details about the creation of the book. I quite like making these for some of my websites, as a little exercise in being thankful and giving some link love to the open source projects and individual contributors that helped make it happen.

--- a/src/links.md
+++ b/src/links.md
@@ -4,7 +4,6 @@ title: Cool links
 updated: 2024-01-26
 metadata:
   description: Cool sites on the information cyber highway that I like.
-eleventyExcludeFromCollections: true
 ---
 
 I am remiss that [websites these days don't just link to cool things anymore]({{ '/blog/2023-11-27-buttons/' | url }}). Of course, when I wrote that article, this website didn't do that either, so let's right that wrong.

--- a/src/privacy.md
+++ b/src/privacy.md
@@ -3,7 +3,6 @@ layout: generic.njk
 title: Privacy
 metadata:
   description: Privacy policy, data collection, etc.
-eleventyExcludeFromCollections: true
 ---
 
 This website doesn't collect any information about the people who visit it outside of basic server logs created by my hosting provider.


### PR DESCRIPTION
The `eleventyExcludeFromCollections` tag is more intended for non-content pages, such as the RSS feed generation file, sitemap generation file, OpenGraph generation files, and 404 page. 

These pages are actually fine being included in Eleventy's collections. 
