### PR TITLE
Add ability for `responsiveImages` to link to themselves

### DIFF
--- a/config/shortcodes/responsiveImages.js
+++ b/config/shortcodes/responsiveImages.js
@@ -11,11 +11,12 @@ const responsiveImagesShortcode = async function (src, alt, args) {
   const defaultArgs = {
     lazy: true,
     classes: "",
+    link: false,
   };
   const settings = { ...defaultArgs, ...args };
 
   let metadata = await pluginImages(src, {
-    widths: [300, 600, 900, 1200],
+    widths: [300, 600, 900, 1200, null],
     formats: ["webp"],
     urlPath: "/images/",
     outputDir: paths.output + "/images/",
@@ -26,10 +27,10 @@ const responsiveImagesShortcode = async function (src, alt, args) {
 
   let originalSize = metadata.webp[metadata.webp.length - 1];
 
-  return `<picture>
+  const imageCode = `<picture>
   ${Object.values(metadata)
     .map((imageFormat) => {
-      return `  <source type="image/${
+      return `<source type="image/${
         imageFormat[0].format
       }" srcset="${imageFormat
         .map((entry) => entry.srcset)
@@ -40,8 +41,14 @@ const responsiveImagesShortcode = async function (src, alt, args) {
     originalSize.url
   }" width="${originalSize.width}" height="${
     originalSize.height
-  }" alt="${alt}"${settings.classes ? ` class="${settings.classes}"` : ""}>
-  </picture>`;
+  }" alt="${alt}"${
+    settings.classes ? ` class="${settings.classes}"` : ""
+  }></picture>`;
+
+  if (settings.link) {
+    return `<a href="${originalSize.url}">${imageCode}</a>`;
+  }
+  return imageCode;
 };
 
 module.exports = responsiveImagesShortcode;

--- a/src/blog/2021-11-22-star-trek-ahoy.njk
+++ b/src/blog/2021-11-22-star-trek-ahoy.njk
@@ -38,47 +38,47 @@ metadata:
 
 <p>I present, the <strong>Star Trek Ahoy</strong> series. <small>(Not in any way affiliated with Star Trek or Ahoy.)</small></p>
 
-{% responsiveImage "./src/images/1 - TMP.png", "Poster for Star Trek: The Motion Picture." %}
+{% responsiveImage "./src/images/1 - TMP.png", "Poster for Star Trek: The Motion Picture.", { link: true } %}
 
 <p>First up, <i>The Motion Picture</i>. As already mentioned, the poster for this film is already a cultural icon, and I didn't want to deviate too far from it. The rainbow gradient got abstracted into a few stripes, added on the customary spaceship—the refit <i>Constitution</i>-class USS <i>Enterprise</i>, NCC-1701, <a href="https://youtu.be/qTOP1BezOB8?t=6">no bloody A, B, C or D</a>—and Bob's your uncle.</p>
 
-{% responsiveImage "./src/images/2 - TWOK.png", "Poster for Star Trek II: The Wrath of Khan." %}
+{% responsiveImage "./src/images/2 - TWOK.png", "Poster for Star Trek II: The Wrath of Khan.", { link: true } %}
 
 <p>Probably many people's favourite, <i>The Wrath of Khan</i>. One thing I didn't want to do in this series was use the same starship twice. <i>TWOK</i> features Kirk and crew (well, not Chekov, to be pedantic) still serving on the refit <i>Constitution</i>-class from the previous film, so the honour here instead lands on the <i>Miranda</i>-class USS <i>Reliant</i> that Khan and the Augments hijack. The colour and composition here are rather intentional, with the <i>Reliant</i> shown flying away from the yellow planet, just as Khan uses it to escape from the desert planet Ceti Alpha V.</p>
 
-{% responsiveImage "./src/images/3 - TSFS.png", "Poster for Star Trek III: The Search for Spock." %}
+{% responsiveImage "./src/images/3 - TSFS.png", "Poster for Star Trek III: The Search for Spock.", { link: true } %}
 
 <p>The ending of <i>The Wrath of Khan</i> ends in the creation of Genesis, a newly terraformed planet that is lush, verdant and very, very blue. In <i>The Search for Spock</i>, the <i>Enterprise</i> crew are trying to get back to it after learning that Spock (who died) isn't actually dead (surprise!), and his miraculously infantilised body is back on Genesis just waiting for them to come and pick him up. Unfortunately for them, Christopher Lloyd is piloting a Klingon bird-of-prey and is determined to get in their way. The <i>Enterprise</i> goes bang, and Kirk and company end up stealing the bird-of-prey for their own uses. Seen here, the bird-of-prey orbiting the (still) very blue Genesis.</p>
 
-{% responsiveImage "./src/images/4 - TVH.png", "Poster for Star Trek IV: The Voyage Home." %}
+{% responsiveImage "./src/images/4 - TVH.png", "Poster for Star Trek IV: The Voyage Home.", { link: true } %}
 
 <p><i>The Voyage Home</i> is a very fun film. It's also one that perhaps afforded the most compromise in this project. Set on Earth in the 1980s, there are ultimately only two spacefaring vessels that get more than a few seconds of screen time in this flick. <em>Two.</em> And one of them is the same bird-of-prey as <i>The Search for Spock</i>. The honour thus falls to the Whale Probe. Yup. The Whale Probe. If you've never seen <i>The Voyage Home</i>, you'll know that the Whale Probe is literally an unornamented cylinder with a hovering ball that likes to scream a lot. It is basically the least interesting or complex ship design imaginable. Good job, Whale Probe. </p>
 
-{% responsiveImage "./src/images/5 - TFF.png", "Poster for Star Trek V: The Final Frontier." %}
+{% responsiveImage "./src/images/5 - TFF.png", "Poster for Star Trek V: The Final Frontier.", { link: true } %}
 
 <p><i>Star Trek V: The One Where They Kill God</i>, known to some as <i>The Final Frontier</i>, is not considered a good film. Part of the central premise of the film directly contradicts later canon in the Trek universe. It randomly reveals that Spock has a half-brother he's never mentioned (which seems to be a running theme, going by <i>Star Trek: Discovery</i>). It's generally not very good. Still, the newly minted <i>Enterprise</i>-A gets her first rodeo here, so she takes pride of place in the thumbnail, alternately seen to be sailing to the centre of the galaxy, or otherwise with an angelic halo surrounding it. After all, is a ship that can kill a god not a god in itself? </p>
 
-{% responsiveImage "./src/images/6 - TUC.png", "Poster for Star Trek VI: The Undiscovered Country." %}
+{% responsiveImage "./src/images/6 - TUC.png", "Poster for Star Trek VI: The Undiscovered Country.", { link: true } %}
 
 <p>Fun fact: <i>The Undiscovered Country</i> was originally going to be the title for <i>The Wrath of Khan</i>, wherein the eponymous "undiscovered country" was death. Here, it represents an unknowable future brought about by the signing of the Khitomer Accords, finally signalling lasting peace between the Federation and the Klingon Empire. Of course, not everyone approves of peace, so the <i>Enterprise</i> crew has to save the day from saboteurs, whilst accused of themselves being the saboteurs.</p>
 
 <p>This thumbnail hosts the <i>Excelsior</i>-class USS <i>Excelsior</i>. Although the <i>Excelsior</i> had already made appearances in the previous three films, here it finally takes centre-stage commanded by Captain Sulu, and effectively plays the role of a second hero ship alongside the <i>Enterprise</i>, affording it the honour of a thumbnail. </p>
 
-{% responsiveImage "./src/images/7 - Generations.png", "Poster for Star Trek VII: Generations." %}
+{% responsiveImage "./src/images/7 - Generations.png", "Poster for Star Trek VII: Generations.", { link: true } %}
 
 <p><i>The Next Generation</i> era of films appropriately started with <i>Generations</i>—the passing-the-baton crossover entry between the original series and its successor. It is also the only Star Trek film to feature the television series' iconic <i>Galaxy</i>-class USS <i>Enterprise</i>-D, so of course, that takes pride of place here. One of the most unique features of this class of ship, I think, is the forward sweeping (and really quite stubby) warp nacelles, which is why I opted to focus on those in the thumbnail. It is backed by The Nexus, a wobbly ribbon of space energy that facilitates the team-up of Kirk and Picard against a rather annoyed Malcolm McDowell.</p>
 
-{% responsiveImage "./src/images/8 - First Contact.png", "Poster for Star Trek VIII: First Contact." %}
+{% responsiveImage "./src/images/8 - First Contact.png", "Poster for Star Trek VIII: First Contact.", { link: true } %}
 
 <p>The Big D ultimately fell victim to production values. The filming model just didn't stand up to the higher resolutions of cinema cameras, and the ship being so wide and dumpy was apparently "uncool" or something. <i>First Contact</i> sees the introduction of the much slimmer, sleeker, and incredibly long <i>Sovereign</i>-class <i>Enterprise</i>-E.</p>
 
 <p>But that's not what's in the thumbnail. The Borg are attacking Earth (and believe me, I was tempted to just draw a square, call it a Borg cube and be done), and most nefariously, they're doing it <em>in the past</em>! The Enterprise crew must travel back to a more primitive time—the 21st Century—to stop the Borg from preventing the first contact between humans and aliens, and let the first warp-speed spaceflight proceed as history demands. It is that ship, Zephram Cochrane's <i>Phoenix</i> that takes pride of place in the thumbnail, just as it has various desk models and <i>Star Trek: Enterprise</i> opening titles throughout Star Trek canon, leaving our blue planet for the reaches of space for the first time.</p>
 
-{% responsiveImage "./src/images/9 - Insurrection.png", "Poster for Star Trek IX: Insurrection." %}
+{% responsiveImage "./src/images/9 - Insurrection.png", "Poster for Star Trek IX: Insurrection.", { link: true } %}
 
 <p><i>Insurrection</i>, aside from being a word that now mainly reminds me of the sixth of January, is an OK film. Not great, not terrible, just like this thumbnail. The <i>Enterprise</i>-E finally gets to show up, selected over various Son'a ships that appear in the film just because they're all pretty unmemorable. (I literally couldn't remember any of them. They're that bad.) Also present in <i>Insurrection</i> is the Federation holoship, which is interesting in concept, but visually is only marginally more interesting than a Borg cube. The <i>Enterprise</i> is here in red, representing Picard's renunciation of Starfleet's actions during the course of this film and the <i>Enterprise</i> subsequently going rogue, hailing back to the hijacked <i>Miranda</i>-class in <i>The Wrath of Khan</i>'s thumbnail.</p>
 
-{% responsiveImage "./src/images/10 - Nemesis.png", "Poster for Star Trek X: Nemesis." %}
+{% responsiveImage "./src/images/10 - Nemesis.png", "Poster for Star Trek X: Nemesis.", { link: true } %}
 
 <p>Ahh, <i>Nemesis</i>. The film that killed the Trek film franchise and—if rumours are to be believed—almost took Tom Hardy's acting career with it. Suffice it to say, many probably consider this to be the worst of the original film run. Hardy plays Shinzon, Picard's age-accelerated clone, the result of an abandoned Romulan plot to sneakily replace prominent Starfleet officers, who has since been left to toil in slave labour on Remus. He gets mad, assassinates the entire Romulan senate, announces himself as the new leader of their society (whut) and builds the <i>Scimitar</i>, a ship so massively overpowered that it has three-times the armament of the <i>Enterprise</i> even before you include the giant radioactive laser beam that can disintegrate thousands of people at once following the just-long-enough-to-create-tension charging sequence.</p>
 

--- a/src/blog/2021-11-23-star-trek-ahoy-2.njk
+++ b/src/blog/2021-11-23-star-trek-ahoy-2.njk
@@ -10,19 +10,19 @@ metadata:
 
 <p>These ones use an inverted, principally white colour palette, reflecting both the alternate timeline and JJ Abrams' very shiny, lens flare-filled vision of the future.</p>
 
-{% responsiveImage "./src/images/11 - Star Trek 2009.png", "Poster for Star Trek (2009)." %}
+{% responsiveImage "./src/images/11 - Star Trek 2009.png", "Poster for Star Trek (2009).", { link: true } %}
 
 <p>Arguably more important than the <i>Enterprise</i> to the <i>Kelvin</i> timeline is the <i>Nerada</i>, the ship whose time travelling schenanigans caused the alternate timeline to diverge.</p>
 
 <p>It's a humongous ship, a Romulan mining vessel supposedly (according to beta canon) augmented with tons of salvaged Borg technology collected over the course of decades. As a result it's also quite pointy for... some reason. Here, it emerges from the wormhole that spawned this new timeline (or, alternatively, it is being sucked into the black hole that seems its demise at the end of the film).</p>
 
-{% responsiveImage "./src/images/12 - Into Darkness.png", "Poster for Star Trek Into Darkness." %}
+{% responsiveImage "./src/images/12 - Into Darkness.png", "Poster for Star Trek Into Darkness.", { link: true } %}
 
 <p>With the <i>Nerada</i> having stolen the limelight for the previous thumbnail, and <i>Into Darkness</i>'s only other iconic ship being the somewhat forgettable (and very dark) <i>Dreadnought</i>-class USS <i>Vengeance</i>, I opted to use this time to show off the Abrams incarnation of the <i>Enterprise</i>.</p>
 
 <p>I'll be honest, I quite like this take on the <i>Enterprise</i>, especially the warp nacelles with their simultaneously sleeker yet sturdier look when compared to The Original Series' cyliners mounted on popsicle sticks design. The all-white interior is certainly more... divisive, but it definitely fits a 21st Century perception of futuristic, Apple-ish design. Here it is shown, appropriately enough, heading into darkness.</p> 
 
-{% responsiveImage "./src/images/13 - Beyond.png", "Poster for Star Trek Beyond." %}
+{% responsiveImage "./src/images/13 - Beyond.png", "Poster for Star Trek Beyond.", { link: true } %}
 
 <p>And finally (at least so far), <i>Beyond</i>. I really like <i>Beyond</i> and the way that it (finally) brought some sort of—not just acknowledgement—but integration of the canon established in <i>Star Trek: Enterprise</i> into other Star Trek properties, with Balthazar Edison, the MACOs, and the star of our thumbnail, the <i>Freedom</i>-class USS <i>Franklin</i>.</p>
 

--- a/src/blog/2023-07-25-20-years.md
+++ b/src/blog/2023-07-25-20-years.md
@@ -23,7 +23,7 @@ These websites often included personal information about myself and others that 
 ## Genesis
 
 {% figure float="right", caption="My first website." %}
-{% responsiveImage "./src/images/first-website.png", "A narrow screenshot of a webpage with a dark grey background, white central column and lots of reddish-pink accents. It has small headings like 'Latest News!!', 'Sign my Guestbook' and 'What's Your Number?' at the top of each section. There are broken images all over the place." %}
+{% responsiveImage "./src/images/first-website.png", "A narrow screenshot of a webpage with a dark grey background, white central column and lots of reddish-pink accents. It has small headings like 'Latest News!!', 'Sign my Guestbook' and 'What's Your Number?' at the top of each section. There are broken images all over the place.", { link: true } %}
 {% endfigure %}
 
 It was 25th April 2003, whilst kinda bored during a visit to my aunt's house in Cardiff, that I first laid code to text editor. A little of it, at least. My first website was about _The Sims_ video game. Creatively named "The Sims on the Web", it contained information you could find a hundred other places online: cheat codes, snippets of info about upcoming expansions and the then-revolutionary _The Sims Online_, screenshots from the game, and naturally it had a guestbook.
@@ -41,7 +41,7 @@ I ended up moving to Bravehost (today, with almost an identical logo to 2003, [B
 It was actually a great place to flex my first attempts at actually coding the entire website!
 
 {% figure caption="My first hand-coded website." %}
-{% responsiveImage "./src/images/first-bravehost-website.png", "A screenshot of a basic webpage with black text and several horizontal rules placed against an obnoxiously cyan background. About half of the page is taken up by banner adverts." %}
+{% responsiveImage "./src/images/first-bravehost-website.png", "A screenshot of a basic webpage with black text and several horizontal rules placed against an obnoxiously cyan background. About half of the page is taken up by banner adverts.", { link: true } %}
 {% endfigure %}
 
 Wow... that is **obnoxiously** blue, huh. This is also the first appearance of the "robomilk" moniker, my first online username and one survived to this day by [my still-active Last.fm](https://www.last.fm/user/robomilk) and [Wikipedia accounts](https://en.wikipedia.org/wiki/User:Robomilk).
@@ -51,7 +51,7 @@ The code is bad, maybe even for the time. At this time, I was learning how to co
 Still, the starting gun was fired, and much like my modern crippling need to constantly iterate my personal website, the RoboMilk website underwent a complete redesign basically every month.
 
 {% figure caption="RoboMilk website, version 2." %}
-{% responsiveImage "./src/images/second-bravehost-website.png", "A screenshot of a basic webpage with a medium green background, a bright green header and sidebar navigation, and a dark green content area. It has an extremely pixellated logo reading 'RMR RoboMilk Regeneration' in a swooshy script font." %}
+{% responsiveImage "./src/images/second-bravehost-website.png", "A screenshot of a basic webpage with a medium green background, a bright green header and sidebar navigation, and a dark green content area. It has an extremely pixellated logo reading 'RMR RoboMilk Regeneration' in a swooshy script font.", { link: true } %}
 {% endfigure %}
 
 Version two had tables! For layout! And all my styles were still HTML attributes! And it was obnoxiously green instead!
@@ -59,7 +59,7 @@ Version two had tables! For layout! And all my styles were still HTML attributes
 Around this time I started making websites for my school friends. Probably the premiere amongst these would be "CSN Animations"—the sequel to a site called animationsx and prequel to one named Motus Animation—all of which hosted various Flash animations created by about half a dozen of my peers. It was impeccable. It had actual CSS! And rounded corners before `border-radius` existed!
 
 {% figure caption="The CSN Animations website." %}
-{% responsiveImage "./src/images/csn-animations-website.png", "A screenshot of a narrow webpage with an orange-to-white gradient background and several bright orange boxes with a single rounded corner, containing a mixture of black and white text." %}
+{% responsiveImage "./src/images/csn-animations-website.png", "A screenshot of a narrow webpage with an orange-to-white gradient background and several bright orange boxes with a single rounded corner, containing a mixture of black and white text.", { link: true } %}
 {% endfigure %}
 
 I don't think it looks that bad even now, to be honest, if a little EasyJet.
@@ -77,7 +77,7 @@ Following this, there was a period of a few years where I didn't operate a perso
 ## Numbers
 
 {% figure float="right", caption="The 2010 holding page, featuring a suspiciously familiar logo&hellip;" %}
-{% responsiveImage "./src/images/personal-website-2010.png", "A screenshot of a holding page from 2010, with an ASCII art representation of a bat's head in silhouette, with a gear-like symbol inside of it. Text below the art reads 'A website belonging to [REDACTED], (hopefully) coming soon." %}
+{% responsiveImage "./src/images/personal-website-2010.png", "A screenshot of a holding page from 2010, with an ASCII art representation of a bat's head in silhouette, with a gear-like symbol inside of it. Text below the art reads 'A website belonging to [REDACTED], (hopefully) coming soon.", { link: true } %}
 {% endfigure %}
 
 It wouldn't be until 2010 that I started working on a new personal website. This was also around the time I stopped using my birth name in favour of a moniker. My university years were initially branded under the name "Furrified" (a domain originally picked up for, unsurprisingly, an unrealised furry fandom project), with the subtitle "Grey's Adventures in Web Design".
@@ -85,13 +85,13 @@ It wouldn't be until 2010 that I started working on a new personal website. This
 Building on my earlier experimentation with PHP, this was one of my first websites to be built on the WordPress content management system, a CMS I'd use for a great number of websites to the present day.
 
 {% figure caption="The website for Furrified: Grey's Adventures in Web Design, with photo redacted." %}
-{% responsiveImage "./src/images/furrified-v1.png", "A screenshot of a monochromatic black and white webpage, with a photograph of the author creatively redacted with a smiley emoji." %}
+{% responsiveImage "./src/images/furrified-v1.png", "A screenshot of a monochromatic black and white webpage, with a photograph of the author creatively redacted with a smiley emoji.", { link: true } %}
 {% endfigure %}
 
 Little did I know that this would become a period of great upheaval. This website, true to my Sisyphean curse, did not survive the year and was replaced by a holding page until some time in 2012.
 
 {% figure float="right", caption="Grey's Adventures, now in mobile sizes!" %}
-{% responsiveImage "./src/images/greysadventures-v1.png", "A mobile screenshot of a monochromatic black and white webpage, with large bold text reading 'Grey [REDACTED]. Web developer, bit of a weirdo.' atop a halftone shaded background." %}
+{% responsiveImage "./src/images/greysadventures-v1.png", "A mobile screenshot of a monochromatic black and white webpage, with large bold text reading 'Grey [REDACTED]. Web developer, bit of a weirdo.' atop a halftone shaded background.", { link: true } %}
 {% endfigure %}
 
 The new website, now simply retitled "Grey's Adventures" was my first personal website (at least, that I can recall) that was responsive. This was literally less than a year after Ethan Marcotte's groundbreaking [_Responsive Web Design_ book](https://abookapart.com/products/responsive-web-design) was released. You could say I was a bit of an early adopter.
@@ -103,19 +103,19 @@ This website also did not last particularly long, by 2014 it had itself been rep
 Still, I would make updates every few years, just to keep things slightly interesting.
 
 {% figure caption="Grey's Adventures, now in holding page! Used from 2014 until 2017." %}
-{% responsiveImage "./src/images/greysadventures-v2.png", "A screenshot of a webpage, with a turquoise heading reading 'Grey's Adventures' and a large heading reading 'Hello there!' atop a monochrome photograph of a lake and temple in Bali, Indonesia. A row of brightly coloured social media icons cover the bottom of the page." %}
+{% responsiveImage "./src/images/greysadventures-v2.png", "A screenshot of a webpage, with a turquoise heading reading 'Grey's Adventures' and a large heading reading 'Hello there!' atop a monochrome photograph of a lake and temple in Bali, Indonesia. A row of brightly coloured social media icons cover the bottom of the page.", { link: true } %}
 {% endfigure %}
 
 This was originally set in [Brandon Grotesque](https://en.wikipedia.org/wiki/Brandon_Grotesque), though the Wayback Machine doesn't seem to have saved that bit. I didn't suddenly forget about typographic design, honest.
 
 {% figure caption="Holding page, circa 2017 to 2019." %}
-{% responsiveImage "./src/images/kimberly-v1.png", "A screenshot of a webpage, with a purple and pink gradient background and plain white text and icons centred on the page." %}
+{% responsiveImage "./src/images/kimberly-v1.png", "A screenshot of a webpage, with a purple and pink gradient background and plain white text and icons centred on the page.", { link: true } %}
 {% endfigure %}
 
 The last of the holding pages can only be truly experienced in the fullness of animated GIF.
 
 {% figure caption="Holding page, circa 2019 to 2021." %}
-{% responsiveImage "./src/images/kimberly-v2.gif", "An animated GIF of a webpage with a distinct synthwave aesthetic. There is a pink and light blue gradiented background, with faux scanlines on it as if from a CRT monitor. A purple and pink grid 'floor' animates towards the viewer, whilst white text in both English and Japanese hovers up and down above it." %}
+{% responsiveImage "./src/images/kimberly-v2.gif", "An animated GIF of a webpage with a distinct synthwave aesthetic. There is a pink and light blue gradiented background, with faux scanlines on it as if from a CRT monitor. A purple and pink grid 'floor' animates towards the viewer, whilst white text in both English and Japanese hovers up and down above it.", { link: true } %}
 {% endfigure %}
 
 In 2021, I would finally revive the personal website proper, and in a very Ship of Theseus way, that is the website you're currently looking at!
@@ -123,13 +123,13 @@ In 2021, I would finally revive the personal website proper, and in a very Ship 
 The design has changed quite a lot since then, but many elements that persist to this day are there: the use of [Space Mono](https://fonts.google.com/specimen/Space+Mono) and [Space Grotesk](https://fonts.floriankarsten.com/space-grotesk), an abundance of robot bats, a dedicated dark theme, and hints of the same purple and green palette that the site still uses for its light mode.
 
 {% figure caption="The first version of this here very website, light theme." %}
-{% responsiveImage "./src/images/kimberly-v3.png", "A screenshot of a webpage with two columns of black monospace-like text on a white background with a light contour pattern on it. A heading reading 'Hi, I'm Kimberly Grey' is present, with the letters randomly rotated and mirrored. At the top is a short purple bar with a small asexual pride flag hidden on the left side. Along the bottom is a dark purple footer with some social media icons and an illustrated cartoon bat looking and waving at the viewer." %}
+{% responsiveImage "./src/images/kimberly-v3.png", "A screenshot of a webpage with two columns of black monospace-like text on a white background with a light contour pattern on it. A heading reading 'Hi, I'm Kimberly Grey' is present, with the letters randomly rotated and mirrored. At the top is a short purple bar with a small asexual pride flag hidden on the left side. Along the bottom is a dark purple footer with some social media icons and an illustrated cartoon bat looking and waving at the viewer.", { link: true } %}
 {% endfigure %}
 
 Mid-2022 would see what is pretty much the current design introduced, albeit initially with a different homepage layout and dark theme—being deep blue and pink instead of the current black and yellow. It is still, absolutely, recognisably the current website in aesthetic, however.
 
 {% figure caption="The second version of this here very website, dark theme." %}
-{% responsiveImage "./src/images/kimberly-v4.png", "A screenshot of a webpage with columns of white text on a very deep blue (almost black) background, with bright pink links scattered around. The bottom of the page has a bright pink bar, featuring a whole gang of robot bats getting up to schenanigans." %}
+{% responsiveImage "./src/images/kimberly-v4.png", "A screenshot of a webpage with columns of white text on a very deep blue (almost black) background, with bright pink links scattered around. The bottom of the page has a bright pink bar, featuring a whole gang of robot bats getting up to schenanigans.", { link: true } %}
 {% endfigure %}
 
 There would be iterative changes made going forward, including a change of name and domain later in 2022.
@@ -137,7 +137,7 @@ There would be iterative changes made going forward, including a change of name 
 There was a brief sojourn away from the Space typefaces towards using [IBM Plex](https://www.ibm.com/plex/) instead, but I came crawling back a few months later.
 
 {% figure caption="A version of this here very website from later in 2022, dark theme." %}
-{% responsiveImage "./src/images/kimberly-v4.1.png", "A screenshot of a webpage with columns of white text on a dark grey background, with yellow links scattered around. The top of the page features an illustrated robot bat looking and waving at the viewer whilst standing in front of a cut-out photograph of a nebula. Further down, the same bat flies using the help of a jetpack next to a list of blog posts. The bottom of the page has a bright yellow bar, featuring a whole gang of robot bats getting up to schenanigans." %}
+{% responsiveImage "./src/images/kimberly-v4.1.png", "A screenshot of a webpage with columns of white text on a dark grey background, with yellow links scattered around. The top of the page features an illustrated robot bat looking and waving at the viewer whilst standing in front of a cut-out photograph of a nebula. Further down, the same bat flies using the help of a jetpack next to a list of blog posts. The bottom of the page has a bright yellow bar, featuring a whole gang of robot bats getting up to schenanigans.", { link: true } %}
 {% endfigure %}
 
 ## A work in progress

--- a/src/blog/2023-12-10-initial-experiences-using-arc-browser.md
+++ b/src/blog/2023-12-10-initial-experiences-using-arc-browser.md
@@ -29,7 +29,7 @@ A couple of years ago, upon procuring my shiny M1 Pro Mac, I moved to use Firefo
 After some time in a limited beta, Arc went free to use in July of this year. I can't recall if I'd actually heard much about it before then, but the list of features intrigued me—particularly the concepts of "Spaces" and "Boosts".
 
 {% figure caption="This is what Arc looks like, by the way." %}
-{% responsiveImage "./src/images/arc-browser.jpg", "A screenshot of the Arc browser, with the majority of the screen showing the homepage of this website. A narrow purple sidebar on the left shows a grid of buttons with icons in it with a vertical list of tabs beneath it." %}
+{% responsiveImage "./src/images/arc-browser.jpg", "A screenshot of the Arc browser, with the majority of the screen showing the homepage of this website. A narrow purple sidebar on the left shows a grid of buttons with icons in it with a vertical list of tabs beneath it.", { link: true } %}
 {% endfigure %}
 
 Spaces gave you the ability to have multiple simultaneous-but-separate profiles. I already had something like these in Firefox with the first-party [Multi-Account Containers extension](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/) and had found them invaluable to my workflows, so having a version more integrated into the browser was an intriguing concept.
@@ -143,7 +143,7 @@ This is also fairly minor—none of this makes actual development easier—but i
 Maybe just another developer brain thing, but Arc lets you do basically everything through a command palette. New tabs, searching, browser history, extensions, and other commands: all searchable and usable from one place.
 
 {% figure caption="Arc's command palette lets you do almost anything just from your keyboard." %}
-{% responsiveImage "./src/images/arc-browser-commands.jpg", "A screenshot of the Arc browser's command palette. A search field has searched for 'developer', bringing up a list with one open tab, the option to search for 'developer', a history entry for Google Developers, and the options to toggle developer mode and open developer tools." %}
+{% responsiveImage "./src/images/arc-browser-commands.jpg", "A screenshot of the Arc browser's command palette. A search field has searched for 'developer', bringing up a list with one open tab, the option to search for 'developer', a history entry for Google Developers, and the options to toggle developer mode and open developer tools.", { link: true } %}
 {% endfigure %}
 
 As someone who already uses [Raycast](https://www.raycast.com/) to do an awful lot of my computing, having single points of access like this is a huge deal for me.
@@ -205,7 +205,7 @@ No, it's not "real AI" and is just another large language model based on ChatGPT
 What I respect about their implementation is that they haven't just taken ChatGPT and stuffed it in a sidebar. The AI tools are much more specific and nuanced.
 
 {% figure float="right", caption="AI summaries are actually quite useful if you're just looking to get the gist of something." %}
-{% responsiveImage "./src/images/arc-browser-ai-summary.jpg", "A screenshot of a search results page, with the Arc browser summarising an article about the mobile version of itself into a single sentence and list of themed bullet points." %}
+{% responsiveImage "./src/images/arc-browser-ai-summary.jpg", "A screenshot of a search results page, with the Arc browser summarising an article about the mobile version of itself into a single sentence and list of themed bullet points.", { link: true } %}
 {% endfigure %}
 
 I actually quite appreciate the ability to get a summary of a link's content without having to open it. It once again plays to Arc's philosophy of webpages being transient and is a novel way of avoiding clickbait and meandering articles.

--- a/src/test/index.md
+++ b/src/test/index.md
@@ -197,6 +197,10 @@ OK that's about it for now. Bye!
 
 {% responsiveImage "./src/images/emy-by-integration.png", "A warmly lit room. The sun is setting outside of the window. Emy, a white, green and black, anthropomorphic robot bat, sits at a workbench. One wing has been detached and is laying in parts on the bench, whilst she uses the other to repair the parts of the disassembled wing." %}
 
+#### Linked responsive image
+
+{% responsiveImage "./src/images/emy-by-integration.png", "A warmly lit room. The sun is setting outside of the window. Emy, a white, green and black, anthropomorphic robot bat, sits at a workbench. One wing has been detached and is laying in parts on the bench, whilst she uses the other to repair the parts of the disassembled wing.", { link: true } %}
+
 ### Figure
 
 {% figure %}


### PR DESCRIPTION
In some situations an image is displayed smaller than desired to view all of the detail, or the provision of a larger (or 'full size') image is an intended feature of the page. 

## Changes
- Adds a `link` argument to the `responsiveImage` shortcode which, if `true`, generates the image with a link to the largest sized version of the image.
- Tweaks the generation rules so that an 'original size' version of the image is always created (albeit converted to everyone's favourite image format, WebP).

## Todo
- The current link focus style is very tailored towards text-based links and doesn't meet WCAG 2.2 Level AA when applied to images. 