### PR TITLE
Remove dark theme-specific focus colour

### DIFF
--- a/src/assets/settings/_colors.scss
+++ b/src/assets/settings/_colors.scss
@@ -75,11 +75,9 @@ $kim-color-palette-semantic: (
     light: $kim-color-light-purple,
   ),
   focus-background: (
-    dark: #66cbff,
-    light: #ffcc00,
+    dark: #ffcc00,
   ),
   focus-text: (
     dark: #000,
-    light: #000,
   ),
 );


### PR DESCRIPTION
The dark theme no longer uses yellow-orange in its design, so it no longer needs a distinct focus style from the light theme.

## Changes
- Removes having separate `dark` and `light` focus colour definitions in Sass settings. 