### PR TITLE
Add visited link styles

### DIFF
--- a/src/_layouts/layout.njk
+++ b/src/_layouts/layout.njk
@@ -89,7 +89,7 @@
             <ul class="kimList kimFooter_links" aria-labelledby="footer-links-beeps">
               {%- for link in site.footerLinks %}
                 <li>
-                  <a class="kimLink" href="{{ link.href | url }}" {%- for attribute, value in link.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                  <a class="kimLink-plain" href="{{ link.href | url }}" {%- for attribute, value in link.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
                     {{- link.text -}}
                   </a>
                 </li>
@@ -101,7 +101,7 @@
             <ul class="kimList kimFooter_links" aria-labelledby="footer-links-other">
               {%- for link in site.legalLinks %}
                 <li>
-                  <a class="kimLink" href="{{ link.href | url }}" {%- for attribute, value in link.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                  <a class="kimLink-plain" href="{{ link.href | url }}" {%- for attribute, value in link.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
                     {{- link.text -}}
                   </a>
                 </li>
@@ -111,7 +111,7 @@
           <div class="kimGrid_column kimGrid_column-full defiant:kimGrid_column-oneHalf">
             <h2 class="kimHeading-s">Small print</h2>
             {% block copyrights %}
-            <p class="kimBody-s">Content licensed under <a class="kimLink" href="http://creativecommons.org/licenses/by-nc/4.0/" title="Creative Commons Attribution Non-Commercial 4.0">CC BY-NC 4.0</a>. Code available under the <a class="kimLink" href="https://github.com/querkmachine/beeps.website/blob/main/LICENCE">MIT license</a>. Keep circulating <a class="kimLink" href="https://github.com/querkmachine/beeps.website">the HTML</a>.</p>
+            <p class="kimBody-s">Content licensed under <a class="kimLink-plain" href="http://creativecommons.org/licenses/by-nc/4.0/" title="Creative Commons Attribution Non-Commercial 4.0">CC BY-NC 4.0</a>. Code available under the <a class="kimLink-plain" href="https://github.com/querkmachine/beeps.website/blob/main/LICENCE">MIT license</a>. Keep circulating <a class="kimLink-plain" href="https://github.com/querkmachine/beeps.website">the HTML</a>.</p>
             {% endblock %}
             
             {% include "src/_includes/color-scheme-switch.njk" %}

--- a/src/assets/components/_color-scheme-switch.scss
+++ b/src/assets/components/_color-scheme-switch.scss
@@ -31,7 +31,7 @@
   &_input {
     @include a11y.kim-visually-hidden;
     &:checked + #{$self}_label {
-      background-color: colors.kim-color-css("link-hover-accent");
+      background-color: colors.kim-color-css("furniture-alt");
     }
     &:checked + #{$self}_label::before {
       content: "";

--- a/src/assets/components/_interaction-list.scss
+++ b/src/assets/components/_interaction-list.scss
@@ -19,7 +19,7 @@
       colors.kim-color-css("link");
     line-height: 0;
     &:hover {
-      border-color: colors.kim-color-css("link-hover");
+      border-color: colors.kim-color-css("link-underline-hover");
     }
   }
   img {

--- a/src/assets/components/_masthead.scss
+++ b/src/assets/components/_masthead.scss
@@ -36,7 +36,7 @@
     text-decoration: none;
     &:hover {
       #{$self}_logo {
-        fill: colors.kim-color-css("link-hover");
+        fill: colors.kim-color-css("link-underline-hover");
       }
     }
     &:focus-visible {

--- a/src/assets/helpers/_links.scss
+++ b/src/assets/helpers/_links.scss
@@ -36,9 +36,12 @@
 
 @mixin kim-link {
   @include _kim-link-common;
-  @include _kim-link-underline($color: colors.kim-color-css("link-accent"));
+  @include _kim-link-underline($color: colors.kim-color-css("link-underline"));
+  &:visited {
+    text-decoration-color: colors.kim-color-css("link-underline-visited");
+  }
   &:hover {
-    text-decoration-color: colors.kim-color-css("link-hover-accent");
+    text-decoration-color: colors.kim-color-css("link-underline-hover");
   }
 }
 
@@ -47,7 +50,7 @@
   text-decoration: none;
   &:hover {
     @include _kim-link-underline(
-      $color: colors.kim-color-css("link-hover-accent")
+      $color: colors.kim-color-css("link-underline-hover")
     );
   }
 }

--- a/src/assets/settings/_colors.scss
+++ b/src/assets/settings/_colors.scss
@@ -33,17 +33,28 @@ $kim-color-palette-semantic: (
     ),
     light: $kim-color-light-purple,
   ),
-  link-accent: (
-    dark: color.scale($kim-color-brilliant-green-fallback, $alpha: -80%),
-    light: color.scale($kim-color-light-purple, $alpha: -80%),
+  link-underline: (
+    dark:
+      color.mix(
+        $kim-color-brilliant-green-fallback,
+        $kim-color-deep-purple,
+        $weight: 20%
+      ),
+    light: color.mix($kim-color-light-purple, $kim-color-white, $weight: 20%),
   ),
-  link-hover: (
-    dark: $kim-color-light-purple,
-    light: $kim-color-light-green,
+  link-underline-hover: (
+    dark:
+      color.mix(
+        $kim-color-brilliant-green-fallback,
+        $kim-color-deep-purple,
+        $weight: 40%
+      ),
+    light: color.mix($kim-color-light-purple, $kim-color-white, $weight: 40%),
   ),
-  link-hover-accent: (
-    dark: color.scale($kim-color-light-purple, $alpha: -80%),
-    light: color.scale($kim-color-light-green, $alpha: -80%),
+  link-underline-visited: (
+    dark:
+      color.mix($kim-color-light-purple, $kim-color-deep-purple, $weight: 25%),
+    light: color.mix($kim-color-light-green, $kim-color-white, $weight: 25%),
   ),
   furniture: (
     dark: (


### PR DESCRIPTION
Closes #61.

## Changes

- Reworks colours to have distinct visited and hover styles.
- Reclasses footer links to use plain (non-underlined) link style.
- Reworks colour usage on:
  - Colour scheme selector.
  - Masthead logo.
  - Interaction list.